### PR TITLE
feat: added a macro that supports mutable inputs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,10 @@ macro_rules! input_inner{
         let $var=read_value!($sc,$t);
         input_inner!{$sc $($r)*}
     };
+    ($sc:expr,mut $var:ident:$t:tt$($r:tt)*)=>{
+        let mut $var=read_value!($sc,$t);
+        input_inner!{$sc $($r)*}
+    };
 }
 
 #[macro_export]


### PR DESCRIPTION
# Examples:

Supports mutable inputs

```rust
input!(sc=sc, n: usize, mut a: [i32; n]);

input!(sc=sc, mut n: usize);
```